### PR TITLE
Update 100% Satisfaction Guarantee: explicit no-refund policy after 14 days

### DIFF
--- a/src/curriculum/accelerator.html
+++ b/src/curriculum/accelerator.html
@@ -856,7 +856,12 @@
                 <div class="guarantee-card">
                     <div class="guarantee-icon">😍</div>
                     <h3>100% Satisfaction Guarantee</h3>
-                    <p>If you're not completely satisfied with the program for any reason, you can get a full refund up to <strong>14 days into the Onboarding phase</strong>.</p>
+                    <p>If you're not completely satisfied with the program for any reason, you can request a full refund within the first <strong>14 days of the program</strong>. No questions asked.</p>
+                    <div class="guarantee-details">
+                        <div class="guarantee-detail">
+                            <strong>After 14 days:</strong> No refunds will be issued. If life circumstances arise (e.g., you get busy or need a break), we offer a <strong>deferment option</strong> — you can pause and resume your participation for up to <strong>12 months</strong> from your original start date.
+                        </div>
+                    </div>
                 </div>
                 <div class="guarantee-card">
                     <div class="guarantee-icon">💼</div>


### PR DESCRIPTION
## Changes

- **Refund window:** Clarified that full refunds are available within the first **14 days** of the program, no questions asked.
- **After 14 days:** Explicitly states that **no refunds** will be issued after the 14-day window.
- **Deferment option:** Added language about the deferment policy — participants can pause and resume for up to **12 months** from their original start date if life circumstances come up.

## Why

To set clear expectations for participants about the refund and deferment policies.