### PR TITLE
Tone down bold text color in guarantee details

### DIFF
--- a/src/curriculum/accelerator.html
+++ b/src/curriculum/accelerator.html
@@ -286,7 +286,7 @@
             border-left: 3px solid var(--accent-color);
         }
         .guarantee-detail strong {
-            color: var(--text-color);
+            color: var(--text-secondary);
         }
 
         .companies-section {


### PR DESCRIPTION
Follow-up to #11. Changes `.guarantee-detail strong` from `--text-color` to `--text-secondary` so the bold words ("after 14 days", "deferment option", "12 months") don't visually pop more than the surrounding paragraph text.